### PR TITLE
⚡️ fix exposed ports

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -10,9 +10,6 @@ services:
 
   rabbitmq:
     image: rabbitmq:3-management
-    ports:
-      - "15672:15672"
-      - "5672:5672"
     networks:
       - app-net
     environment:
@@ -27,7 +24,7 @@ services:
   bot:
     build: ./homepage_init_bot
     ports:
-      - "8081:8081"
+      - "127.0.0.1:8081:8081"
     networks:
       - app-net
     env_file:
@@ -40,8 +37,6 @@ services:
 
   redis:
     image: redis:7
-    ports:
-      - "6379:6379"
     networks:
       - app-net
 


### PR DESCRIPTION
- fixes #2 
- possibly fixes #1 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Limited service exposure by removing host port publishing for internal services, improving local isolation.
  * Bot service now binds to localhost on port 8081, making it accessible only from the host machine.
  * Network and environment settings remain unchanged; no impact on app features or APIs.
  * Updated underlying components to newer revisions with no functional or behavioral changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->